### PR TITLE
Remove boost and embrace the C++11 equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ For C++:
 * [cmake >= 3.3](https://cmake.org): A build system (GPL)
 * [gmp >= 4.0](http://gmplib.org): Arbitrary precision arithmetic (LGPL)
 * [cblas](http://www.netlib.org/blas/blast-forum/cblas.tgz): C wrappers for BLAS (BSD license)
-* [boost >= 1.46](http://www.boost.org): Not needed if a C++11 standard library exists (Boost Software License)
 
 For Python:
 
@@ -91,11 +90,10 @@ If necessary, dependencies can be installed via one of
 
     # Homebrew (recommended)
     brew install cmake openexr gfortran python #Note: gfortran brew is now part of gcc, so although previous versions can still be accessed, brew install gcc is the preferred method
-    brew install boost # Not needed for 10.9 or later
     sudo pip install --upgrade pip setuptools numpy scipy pytest #numpy and scipy can be
 
     # MacPorts (not recommended).  If you have python 2.7, replace py26 with py27.
-    sudo port -v install python26 py26-numpy cmake boost
+    sudo port -v install python26 py26-numpy cmake
     sudo port -v install py26-scipy py26-py libpng jpeg openexr # optional
     sudo port -v install gcc47 # If clang is unavailable
 
@@ -156,12 +154,6 @@ These options can also be passed via command line to cmake.  Run `ccmake` for a 
 Use `CMAKE_BUILD_TYPE=Debug` for a much slower build with many more assertions:
 
     cmake -DCMAKE_BUILD_TYPE=Debug
-
-### Common Issues
-On recent Linux machines, the boost libraries are already multithread-capable, and will not include the 'mt' suffix. As this is the default in the geode SConstruct, the following should be added in config.py:
-    boost_lib_suffix = ''
-
-
 
 ### Acknowledgements
 

--- a/geode/config.h.in
+++ b/geode/config.h.in
@@ -4,7 +4,6 @@
 #cmakedefine GEODE_THREAD_SAFE true
 #cmakedefine __SSE__
 #cmakedefine GEODE_GMP
-#cmakedefine BOOST_EXCEPTION_DISABLE
 
 #include <geode/python/config.h>
 #include <geode/utility/config.h>

--- a/geode/python/stl.h
+++ b/geode/python/stl.h
@@ -54,7 +54,7 @@ template<class TM> PyObject* to_python_map(const TM& m) {
   Py_XDECREF(dict);
   return 0;
 }
-}
+} // geode namespace
 
 // to_python needs to go in the std namespace to make Koenig lookup work
 namespace std {
@@ -103,9 +103,6 @@ template<class T0,class T1> PyObject* to_python(const pair<T0,T1>& p) {
   return 0;
 }
 
-}
-namespace GEODE_UNORDERED_NAMESPACE {
-
 template<class T,class H> static inline PyObject* to_python(const unordered_set<T,H>& s) {
   return geode::to_python_set(s);
 }
@@ -114,7 +111,7 @@ template<class T,class V,class H> static inline PyObject* to_python(const unorde
   return geode::to_python_map(m);
 }
 
-}
+} // std namespace
 namespace geode {
 
 using std::vector;

--- a/geode/utility/function.h
+++ b/geode/utility/function.h
@@ -1,16 +1,9 @@
-// function<F> out of std:: if available, otherwise boost::
+// function<F> out of std::
 #pragma once
 
 #include <geode/utility/config.h>
-
-#if GEODE_HAS_CPP11_STD_HEADER(<functional>)
 #include <functional>
-#define GEODE_FUNCTION_NAMESPACE std
-#else
-#include <boost/function.hpp>
-#define GEODE_FUNCTION_NAMESPACE boost
-#endif
 
 namespace geode {
-using GEODE_FUNCTION_NAMESPACE::function;
-}
+using std::function;
+} // geode namespace

--- a/geode/utility/smart_ptr.h
+++ b/geode/utility/smart_ptr.h
@@ -1,53 +1,28 @@
-// Pull scoped_ptr and shared_ptr out of std:: if availabe, otherwise boost::
+// Pull scoped_ptr and shared_ptr out of std::
 #pragma once
 
 #include <geode/utility/config.h>
-
-// TODO: I think this header exists pre-C++11 just without shared_ptr, so this will fail on builds using clang without the C++11 stdlib
-#if GEODE_HAS_CPP11_STD_HEADER(<memory>)
+#include <geode/utility/forward.h>
+#include <geode/utility/move.h>
+#include <geode/utility/mpl.h>
+#include <geode/utility/type_traits.h>
 #include <memory>
+#include <vector>
 namespace geode {
 template<class T> using scoped_ptr = std::unique_ptr<T>;
 using std::shared_ptr;
 using std::weak_ptr;
-}
-#define GEODE_SMART_PTR_NAMESPACE std
-#else // No C++11 <memory>
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/weak_ptr.hpp>
-#define GEODE_SMART_PTR_NAMESPACE boost
-namespace geode {
-using boost::scoped_ptr;
-using boost::shared_ptr;
-using boost::weak_ptr;
-}
-#endif
-#include <vector>
-#include <geode/utility/stl.h>
-namespace geode {
 
 using std::vector;
-using GEODE_SMART_PTR_NAMESPACE::const_pointer_cast;
-using GEODE_SMART_PTR_NAMESPACE::static_pointer_cast;
-using GEODE_SMART_PTR_NAMESPACE::dynamic_pointer_cast;
+using std::const_pointer_cast;
+using std::static_pointer_cast;
+using std::dynamic_pointer_cast;
 
 template<class T> struct is_smart_pointer<shared_ptr<T>> : public mpl::true_ {};
-
-#ifdef GEODE_VARIADIC
 
 template<class T,class... Args> static inline shared_ptr<T> new_sp(Args&&... args) {
   return shared_ptr<T>(new T(args...));
 }
-
-#else // Unpleasant nonvariadic versions
-
-template<class T> static inline shared_ptr<T> new_sp() { return shared_ptr<T>(new T()); }
-template<class T,class A0> static inline shared_ptr<T> new_sp(A0&& a0) { return shared_ptr<T>(new T(a0)); }
-template<class T,class A0,class A1> static inline shared_ptr<T> new_sp(A0&& a0,A1&& a1) { return shared_ptr<T>(new T(a0,a1)); }
-template<class T,class A0,class A1,class A2> static inline shared_ptr<T> new_sp(A0&& a0,A1&& a1,A2&& a2) { return shared_ptr<T>(new T(a0,a1,a2)); }
-
-#endif
 
 template<class T> static inline shared_ptr<typename remove_reference<T>::type> new_sp_copy(T&& t) {
   return shared_ptr<typename remove_reference<T>::type>(new typename remove_reference<T>::type(geode::forward<T>(t)));
@@ -72,4 +47,4 @@ template<class T> shared_ptr<const vector<T>> new_copy_with_erased(const shared_
   return result;
 }
 
-}
+} // geode namespace

--- a/geode/utility/stl.h
+++ b/geode/utility/stl.h
@@ -197,15 +197,13 @@ inline std::ostream &operator<<(std::ostream &os, std::map<T,U> const &v) {
 }
 
 }
-namespace GEODE_SMART_PTR_NAMESPACE {
+
+namespace std {
 
 template<class T> static inline geode::Hash hash_reduce(const shared_ptr<T>& p) {
   using geode::hash_reduce;
   return hash_reduce(p.get());
 }
-
-}
-namespace std {
 
 template<class T, class U> geode::Hash hash_reduce(const std::pair<T,U>&s) {
   return geode::Hash(s.first, s.second);

--- a/geode/utility/tr1.h
+++ b/geode/utility/tr1.h
@@ -3,21 +3,14 @@
 
 #include <geode/utility/config.h>
 
-#if GEODE_HAS_CPP11_STD_HEADER(<unordered_set>) && GEODE_HAS_CPP11_STD_HEADER(<unordered_map>)
 #include <unordered_set>
 #include <unordered_map>
-#define GEODE_UNORDERED_NAMESPACE std
-#else
-#include <boost/tr1/unordered_set.hpp>
-#include <boost/tr1/unordered_map.hpp>
-#define GEODE_UNORDERED_NAMESPACE boost
-#endif
 
 namespace geode {
 
-using GEODE_UNORDERED_NAMESPACE::unordered_set;
-using GEODE_UNORDERED_NAMESPACE::unordered_map;
-using GEODE_UNORDERED_NAMESPACE::unordered_multiset;
-using GEODE_UNORDERED_NAMESPACE::unordered_multimap;
+using std::unordered_set;
+using std::unordered_map;
+using std::unordered_multiset;
+using std::unordered_multimap;
 
-}
+} // namespace geode

--- a/geode/utility/type_traits.h
+++ b/geode/utility/type_traits.h
@@ -1,96 +1,49 @@
-// Pull type_traits out of std:: if available, otherwise boost::
+// Pull type_traits out of std:: and define a few aliases and utilities
 #pragma once
 
 #include <geode/utility/config.h> // Must be included first
 #include <geode/utility/mpl.h>
 
-#if GEODE_HAS_CPP11_STD_HEADER(<type_traits>)
 #include <cstdint>
 #include <type_traits>
-#define GEODE_TYPE_TRAITS_NAMESPACE std
 namespace geode {
 template<class T> struct add_reference : public std::add_lvalue_reference<T> {};
 template<bool c,class T=void> struct enable_if_c : public std::enable_if<c,T> {};
 template<bool c,class T=void> struct disable_if_c : public std::enable_if<!c,T> {};
 template<class C,class T=void> struct enable_if : public std::enable_if<C::value,T> {};
 template<class C,class T=void> struct disable_if : public std::enable_if<!C::value,T> {};
-}
-#else
 
-// No <type_traits> header, so pull everything out of boost.  We need at least boost-1.47.
-#include <boost/version.hpp>
-#if BOOST_VERSION < 104700
-#error "Since we lack the C++11 header <type_traits>, we need at least boost 1.47 for correct type traits."
-#endif
-
-#include <boost/type_traits/add_const.hpp>
-#include <boost/type_traits/add_reference.hpp>
-#include <boost/type_traits/aligned_storage.hpp>
-#include <boost/type_traits/alignment_of.hpp>
-#include <boost/type_traits/common_type.hpp>
-#include <boost/type_traits/has_trivial_destructor.hpp>
-#include <boost/type_traits/is_base_of.hpp>
-#include <boost/type_traits/is_class.hpp>
-#include <boost/type_traits/is_const.hpp>
-#include <boost/type_traits/is_convertible.hpp>
-#include <boost/type_traits/is_empty.hpp>
-#include <boost/type_traits/is_enum.hpp>
-#include <boost/type_traits/is_floating_point.hpp>
-#include <boost/type_traits/is_fundamental.hpp>
-#include <boost/type_traits/is_integral.hpp>
-#include <boost/type_traits/is_pointer.hpp>
-#include <boost/type_traits/is_reference.hpp>
-#include <boost/type_traits/is_same.hpp>
-#include <boost/type_traits/remove_const.hpp>
-#include <boost/type_traits/remove_pointer.hpp>
-#include <boost/type_traits/remove_reference.hpp>
-#include <boost/utility/declval.hpp>
-#include <boost/utility/enable_if.hpp>
-#include <boost/utility/result_of.hpp>
-#define GEODE_TYPE_TRAITS_NAMESPACE boost
-namespace geode {
-using GEODE_TYPE_TRAITS_NAMESPACE::add_reference;
-using GEODE_TYPE_TRAITS_NAMESPACE::disable_if;
-using GEODE_TYPE_TRAITS_NAMESPACE::disable_if_c;
-using GEODE_TYPE_TRAITS_NAMESPACE::enable_if;
-using GEODE_TYPE_TRAITS_NAMESPACE::enable_if_c;
-}
-
-#endif
-
-namespace geode {
-
-using GEODE_TYPE_TRAITS_NAMESPACE::add_const;
-using GEODE_TYPE_TRAITS_NAMESPACE::aligned_storage;
-using GEODE_TYPE_TRAITS_NAMESPACE::alignment_of;
-using GEODE_TYPE_TRAITS_NAMESPACE::common_type;
-using GEODE_TYPE_TRAITS_NAMESPACE::declval;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_base_of;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_class;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_const;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_convertible;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_empty;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_enum;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_floating_point;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_fundamental;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_integral;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_pointer;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_reference;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_same;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_signed;
-using GEODE_TYPE_TRAITS_NAMESPACE::is_unsigned;
-using GEODE_TYPE_TRAITS_NAMESPACE::make_unsigned;
-using GEODE_TYPE_TRAITS_NAMESPACE::remove_const;
-using GEODE_TYPE_TRAITS_NAMESPACE::remove_pointer;
-using GEODE_TYPE_TRAITS_NAMESPACE::remove_reference;
-using GEODE_TYPE_TRAITS_NAMESPACE::result_of;
+using std::add_const;
+using std::aligned_storage;
+using std::alignment_of;
+using std::common_type;
+using std::declval;
+using std::is_base_of;
+using std::is_class;
+using std::is_const;
+using std::is_convertible;
+using std::is_empty;
+using std::is_enum;
+using std::is_floating_point;
+using std::is_fundamental;
+using std::is_integral;
+using std::is_pointer;
+using std::is_reference;
+using std::is_same;
+using std::is_signed;
+using std::is_unsigned;
+using std::make_unsigned;
+using std::remove_const;
+using std::remove_pointer;
+using std::remove_reference;
+using std::result_of;
 
 // Provide is_trivially_destructible as alias of has_trivial_destructor or manually implement it
 #ifdef __GNUC__
 // The following don't necessary exist on Mac, so implement them ourselves if possible
 template<class T> struct is_trivially_destructible : public mpl::bool_<__has_trivial_destructor(T)> {};
 #else
-using GEODE_TYPE_TRAITS_NAMESPACE::is_trivially_destructible;
+using std::is_trivially_destructible;
 #endif
 
 // Add a few more useful ones
@@ -109,4 +62,4 @@ UINT(32)
 UINT(64)
 #undef UINT
 
-}
+} // geode namespace


### PR DESCRIPTION
Fixes #76. It would be good to have some other people try and build this on different platforms. I've only tested it on OSX so far.

There's still a bunch of pre-C++11 support cruft elsewhere I'd like to clean up (particularly GEODE_VARIADIC), but that can come later.