### PR TITLE
cmake: add a develop target that runs setup.py develop

### DIFF
--- a/geode/CMakeLists.txt
+++ b/geode/CMakeLists.txt
@@ -92,4 +92,11 @@ if (PYTHON_FOUND)
   file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
   install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
+
+  add_custom_target(develop DEPENDS geode)
+  add_custom_command(
+    TARGET develop
+    COMMAND ${CMAKE_SOURCE_DIR}/setup.py develop
+  )
+  install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
 endif()


### PR DESCRIPTION
This implements a way to 'install' geode in develop mode inside of a python virtualenv.