### PR TITLE
Detect and use LibJPEG if available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.2)
 include(GeodeSupport.cmake)
 
 find_package(PkgConfig)
+find_package(JPEG)
 
 set(GMP_LIB_DIR "/usr/lib/" CACHE PATH "Path to libgmp.so")
 set(GMP_INCLUDE_DIR "/usr/local/Cellar/ /usr/include/" CACHE PATH "Path to gmp.h")

--- a/geode/CMakeLists.txt
+++ b/geode/CMakeLists.txt
@@ -5,6 +5,10 @@ endif()
 if (GMP_FOUND)
   set(GEODE_GMP YES)
 endif()
+if (JPEG_FOUND)
+  set(GEODE_LIBJPEG YES)
+endif()
+
 configure_file(
   ${CMAKE_CURRENT_SOURCE_DIR}/config.h.in
   ${CMAKE_CURRENT_BINARY_DIR}/config.h
@@ -60,6 +64,20 @@ if (GMP_FOUND)
   )
 else()
   message(STATUS "GMP_FOUND not set")
+endif()
+
+if (JPEG_FOUND)
+  target_include_directories(
+    geode
+    PUBLIC
+      ${JPEG_INCLUDE}
+  )
+
+  target_link_libraries(
+    geode
+    PUBLIC
+      ${JPEG_LIBRARIES}
+  )
 endif()
 
 if (PYTHON_FOUND)


### PR DESCRIPTION
Test failure seems to be from some nondeterministic interaction between Jenkins and python virtualenv. I'm pretty confident it's unrelated to any changes in this branch.

It would be good to verify that build succeeds and check if GEODE_LIBJPEG is defined in build/geode/config.h iff libjpeg is installed.