### PR TITLE
cmake: use CURRENT_*_DIR for cases where geode is included as part of a bigger project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ else()
   message(FATAL_ERROR "Required dependency GMP not found. Set GMP_LIB_DIR and GMP_INCLUDE_DIR to inform cmake where to look")
 endif()
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/)
 find_package(PathPython)
 
 if(NOT PYTHON_FOUND)
@@ -35,7 +35,7 @@ endif()
 
 add_subdirectory(geode)
 
-configure_file(${CMAKE_SOURCE_DIR}/geode.pc.in ${CMAKE_BINARY_DIR}/geode.pc
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/geode.pc.in ${CMAKE_BINARY_DIR}/geode.pc
   @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/geode.pc DESTINATION lib/pkgconfig/)
 

--- a/GeodeSupport.cmake
+++ b/GeodeSupport.cmake
@@ -69,8 +69,8 @@ macro(ADD_GEODE_MODULE _name)
     target_include_directories(
       ${_name}
       PUBLIC
-        ${CMAKE_SOURCE_DIR}
-        ${CMAKE_BINARY_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../../
+        ${CMAKE_CURRENT_BINARY_DIR}/../../
     )
     
     if (GMP_FOUND)

--- a/geode/CMakeLists.txt
+++ b/geode/CMakeLists.txt
@@ -38,6 +38,7 @@ target_include_directories(
   geode
   INTERFACE
     $<INSTALL_INTERFACE:include/>
+    ${PYTHON_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../>
 )
@@ -79,8 +80,8 @@ if (PYTHON_FOUND)
   target_include_directories(
     geode_wrap
     PUBLIC
-      ${CMAKE_SOURCE_DIR}
-      ${CMAKE_BINARY_DIR}
+      ${CMAKE_CURRENT_SOURCE_DIR}/../
+      ${CMAKE_CURRENT_BINARY_DIR}/../
   )
 
   target_compile_features(
@@ -91,12 +92,12 @@ if (PYTHON_FOUND)
 
   file(COPY __init__.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
-  install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
+  install(CODE "execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
 
   add_custom_target(develop DEPENDS geode)
   add_custom_command(
     TARGET develop
-    COMMAND ${CMAKE_SOURCE_DIR}/setup.py develop
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/setup.py develop
   )
-  install(CODE "execute_process(COMMAND ${CMAKE_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
+  install(CODE "execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/setup.py install --prefix ${CMAKE_INSTALL_PREFIX})")
 endif()


### PR DESCRIPTION
These changes enable geode to be built as part of a larger super-project (such as a hypothetical inflatable CAD tool) by using relative path variables instead of absolute.