### PR TITLE
Bug fix in exact ccd collision detection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,7 @@ node {
     echo "Using CC=${cc}, CXX=${cxx}"
 
     withVirtualenv(pwd() + "/virtualenv") {
-      sh "python -m pip install numpy pytest scipy"
+      sh "python -m pip install --upgrade numpy pytest scipy"
       withEnv(["CC=${cc}", "CXX=${cxx}"]) {
         stage('Checkout') {
           checkout scm

--- a/geode/exact/collision.cpp
+++ b/geode/exact/collision.cpp
@@ -522,8 +522,8 @@ inline void edge_edge_collision_function(const Vec3d &d_x0,    const Vec3d &d_x1
     }
     
     out[0] = Interval(-out_lower[0],out_upper[0]);
-    out[1] = Interval(-out_lower[0],out_upper[1]);
-    out[2] = Interval(-out_lower[0],out_upper[2]);
+    out[1] = Interval(-out_lower[1],out_upper[1]);
+    out[2] = Interval(-out_lower[2],out_upper[2]);
 }
 
 


### PR DESCRIPTION
A bug in geode's rendition of Tyson Brochu implementation of the result from  the paper Efficient Geometrically Exact Continuous Collision Detection by Brochu, Edwards, and Bridson.